### PR TITLE
feat: TRM-34190 Update proteome component field to include id and component name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,6 @@
 		</dependencies>
 	</dependencyManagement>
 
-
 	<dependencies>
 		<!-- Tests -->
 		<dependency>
@@ -135,6 +134,12 @@
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
 			<version>${hamcrest.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/uniprot-config/src/main/resources/search-fields-config/uniprotkb-search-fields.json
+++ b/uniprot-config/src/main/resources/search-fields-config/uniprotkb-search-fields.json
@@ -851,6 +851,13 @@
   {
     "parentId": "proteomes",
     "childNumber": 0,
+    "id": "proteomecomponent",
+    "label": "Proteome Component",
+    "itemType": "SIBLING_GROUP"
+  },
+  {
+    "parentId": "proteomecomponent",
+    "childNumber": 0,
     "fieldType": "GENERAL",
     "itemType": "SINGLE",
     "label": "Proteome ID",
@@ -863,7 +870,7 @@
     "includeInSwagger": true
   },
   {
-    "parentId": "proteomes",
+    "parentId": "proteomecomponent",
     "childNumber": 1,
     "fieldType": "GENERAL",
     "itemType": "SINGLE",
@@ -876,7 +883,7 @@
   },
   {
     "parentId": "proteomes",
-    "childNumber": 2,
+    "childNumber": 1,
     "id": "is_gene_centric",
     "label": "Gene Centric",
     "fieldName": "is_gene_centric",

--- a/uniprot-config/src/test/java/org/uniprot/store/config/searchfield/factory/SearchFieldConfigFactoryTest.java
+++ b/uniprot-config/src/test/java/org/uniprot/store/config/searchfield/factory/SearchFieldConfigFactoryTest.java
@@ -59,7 +59,7 @@ class SearchFieldConfigFactoryTest {
                 Arguments.of(UniProtDataType.SUGGEST, 3),
                 Arguments.of(UniProtDataType.TAXONOMY, 15),
                 Arguments.of(UniProtDataType.UNIPARC, 21),
-                Arguments.of(UniProtDataType.UNIPROTKB, 393 + uniProtKBDBTypesCount),
+                Arguments.of(UniProtDataType.UNIPROTKB, 394 + uniProtKBDBTypesCount),
                 Arguments.of(UniProtDataType.UNIREF, 17),
                 Arguments.of(UniProtDataType.UNIRULE, 30),
                 Arguments.of(UniProtDataType.HELP, 8),


### PR DESCRIPTION
In addition to the main change this PR adds missing slf4j static logger binder for tests.

Tested with chrome local overrides and frontend behaves as expected.

<img width="1762" height="1820" alt="image" src="https://github.com/user-attachments/assets/ace8cb41-e3cb-471b-8c10-cccb508e5923" />
