### PR TITLE
feat: TRM-34222: Update proteome component field to include proteome id

### DIFF
--- a/indexer/src/main/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtEntryConverterUtil.java
+++ b/indexer/src/main/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtEntryConverterUtil.java
@@ -227,11 +227,12 @@ public class UniProtEntryConverterUtil {
 
     public static void addProteomesXrefToDocument(
             UniProtDocument document, UniProtKBCrossReference xref) {
-        document.proteomes.add(xref.getId());
+        String proteomeId = xref.getId();
+        document.proteomes.add(proteomeId);
         if (xref.hasProperties()) {
             document.proteomeComponents.addAll(
                     xref.getProperties().stream()
-                            .map(Property::getValue)
+                            .map(property -> proteomeId + ":" + property.getValue())
                             .collect(Collectors.toSet()));
 
             document.content.addAll(getCrossRefPropertiesValues(xref));

--- a/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryCrossReferenceConverterTest.java
+++ b/indexer/src/test/java/org/uniprot/store/indexer/uniprotkb/converter/UniProtKBEntryCrossReferenceConverterTest.java
@@ -59,7 +59,7 @@ class UniProtKBEntryCrossReferenceConverterTest {
         assertEquals(1L, document.xrefCountMap.get("xref_count_proteomes"));
 
         assertEquals(Collections.singleton("id value"), document.proteomes);
-        assertEquals(Collections.singleton("PC12345"), document.proteomeComponents);
+        assertEquals(Collections.singleton("id value:PC12345"), document.proteomeComponents);
         assertEquals(Collections.singleton("PC12345"), document.content);
     }
 

--- a/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/uniprot/converter/UniProtKBEntryCrossReferenceConverterTest.java
+++ b/spark-indexer/src/test/java/org/uniprot/store/spark/indexer/uniprot/converter/UniProtKBEntryCrossReferenceConverterTest.java
@@ -51,7 +51,7 @@ class UniProtKBEntryCrossReferenceConverterTest {
         assertEquals(1L, document.xrefCountMap.get("xref_count_proteomes"));
 
         assertEquals(Collections.singleton("id value"), document.proteomes);
-        assertEquals(Collections.singleton("PC12345"), document.proteomeComponents);
+        assertEquals(Collections.singleton("id value:PC12345"), document.proteomeComponents);
         assertEquals(Collections.singleton("PC12345"), document.content);
     }
 


### PR DESCRIPTION
There was a requirement under https://embl.atlassian.net/browse/TRM-34190 to make UniProtKB Proteome ID and Component search similar to UniParc and the related search-fields endpoint changes were done under that.

This PR is for the follow up task to update indexing of UniProtKB to support Proteome Id and Proteoeme component together so that search is supported on Solr side.